### PR TITLE
Upgrade Groovy to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,20 +97,16 @@
     </mailingLists>
 
     <properties>
+        <pgpVerifyKeysVersion>1.9.5</pgpVerifyKeysVersion>
+        <maven.compiler.release>17</maven.compiler.release>
+
         <connectorPackage>org.forgerock.openicf</connectorPackage>
         <connectorClass>ScriptedConnector</connectorClass>
         <framework.compatibilityVersion>1.5</framework.compatibilityVersion>
         <framework.releaseVersion>3.1</framework.releaseVersion>
+
         <wrensec.commons.version>22.6.1</wrensec.commons.version>
         <openicf.maven.plugin.version>1.5.0</openicf.maven.plugin.version>
-        <openicf.osgi.import.defaults>
-            org.codehaus.groovy*;version="[2.2,3)",
-            groovy.*;version="[2.2,3)",
-            groovyjar*;version="[2.2,3)",
-            groovyx.net.http*;resolution:=optional,
-            org.apache.http*;version="[4.3.0, 4.4.0)";resolution:=optional
-        </openicf.osgi.import.defaults>
-        <openicf.osgi.embed />
     </properties>
 
     <dependencies>
@@ -120,10 +116,28 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.21</version>
+            <version>5.0.2</version>
+            <type>pom</type>
             <scope>provided</scope>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-test</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-test-junit5</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Scripted SQL dependencies -->
@@ -297,6 +311,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <release>${maven.compiler.release}</release>
                     <testExcludes>
                         <exclude>src/test/resources/**/*.groovy</exclude>
                     </testExcludes>
@@ -306,7 +321,10 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.13.1</version>
+                <version>4.2.1</version>
+                <configuration>
+                    <targetBytecode>${maven.compiler.release}</targetBytecode>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -323,11 +341,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Require-Bundle>groovy-all</Require-Bundle>
-                    </instructions>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright (c) 2011-2014 ForgeRock AS. All rights reserved.
-    Portions Copyright 2018-2022 Wren Security.
+    Portions Copyright 2018-2025 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -35,6 +35,7 @@
     </description>
 
     <url>https://github.com/WrenSecurity/wrenicf-groovy-connector</url>
+
     <scm>
         <url>https://github.com/WrenSecurity/wrenicf-groovy-connector</url>
         <connection>scm:git:git://github.com/WrenSecurity/wrenicf-groovy-connector.git</connection>
@@ -61,24 +62,30 @@
             <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
             <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
             <releases>
                 <enabled>true</enabled>
             </releases>
         </repository>
+
         <repository>
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
             <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+
             <releases>
                 <enabled>false</enabled>
             </releases>
         </repository>
+
     </repositories>
 
     <issueManagement>
@@ -144,7 +151,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
-            <version>7.0.53</version>
+            <version>9.0.112</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -156,11 +163,13 @@
             <version>0.7.1</version>
             <scope>provided</scope>
             <optional>true</optional>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>
+
                 <exclusion>
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
@@ -230,8 +239,9 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -263,21 +273,21 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.46.v20220331</version>
+            <version>10.0.26</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.46.v20220331</version>
+            <version>10.0.26</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.212</version>
+            <version>2.2.222</version>
             <scope>test</scope>
         </dependency>
 
@@ -292,14 +302,14 @@
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-api</artifactId>
-            <version>4.9.0</version>
+            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-core</artifactId>
-            <version>4.9.0</version>
+            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -310,8 +320,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+
                 <configuration>
                     <release>${maven.compiler.release}</release>
+
                     <testExcludes>
                         <exclude>src/test/resources/**/*.groovy</exclude>
                     </testExcludes>
@@ -322,9 +334,11 @@
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
                 <version>4.2.1</version>
+
                 <configuration>
                     <targetBytecode>${maven.compiler.release}</targetBytecode>
                 </configuration>
+
                 <executions>
                     <execution>
                         <goals>
@@ -346,6 +360,7 @@
             <plugin>
                 <groupId>org.forgerock.maven.plugins</groupId>
                 <artifactId>openicf-maven-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <goals>
@@ -358,14 +373,18 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.6.1</version>
+
                 <executions>
                     <execution>
                         <id>reserve-network-port</id>
+
                         <goals>
                             <goal>reserve-network-port</goal>
                         </goals>
+
                         <phase>process-resources</phase>
+
                         <configuration>
                             <portNames>
                                 <portName>jetty.http.port</portName>
@@ -378,6 +397,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+
                 <configuration>
                     <systemPropertyVariables>
                         <jetty.http.port>${jetty.http.port}</jetty.http.port>
@@ -388,6 +408,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+
                 <configuration>
                     <excludes>**/generated-sources/groovy-stubs/**/*</excludes>
                 </configuration>
@@ -396,6 +417,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
+
                 <configuration>
                     <excludes>
                         <exclude>**/groovy-stubs/*.java</exclude>
@@ -411,12 +433,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>3.2.0</version>
+
                 <configuration>
                     <linkJavadoc>true</linkJavadoc>
+
                     <includes>
                         <include>**/*.java</include>
                         <include>**/*.groovy</include>
                     </includes>
+
                     <excludes>
                         <exclude>target/generated/groovy-stubs</exclude>
                     </excludes>
@@ -426,14 +451,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+
                 <configuration>
                     <descriptors>
                         <descriptor>src/assemble/samples.xml</descriptor>
                     </descriptors>
                 </configuration>
+
                 <executions>
                     <execution>
                         <phase>package</phase>
+
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/src/main/groovy/org/forgerock/openicf/connectors/scriptedsql/ScriptedSQLConfiguration.groovy
+++ b/src/main/groovy/org/forgerock/openicf/connectors/scriptedsql/ScriptedSQLConfiguration.groovy
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * " Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyright 2025 Wren Security.
  *
  */
 
@@ -90,7 +91,7 @@ public class ScriptedSQLConfiguration extends ScriptedConfiguration {
      */
     static final Log log = Log.getLog(ScriptedSQLConfiguration.class);
 
-    @Delegate(excludes = "password")
+    @Delegate(excludes = ["getPassword", "setPassword"])
     private final PoolProperties poolProperties = new PoolProperties();
 
     // =======================================================================

--- a/src/main/groovy/org/forgerock/openicf/misc/scriptedcommon/ConnectorObjectDelegate.groovy
+++ b/src/main/groovy/org/forgerock/openicf/misc/scriptedcommon/ConnectorObjectDelegate.groovy
@@ -20,7 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
- * Portions Copyright 2022 Wren Security.
+ * Portions Copyright 2022-2025 Wren Security.
  */
 
 package org.forgerock.openicf.misc.scriptedcommon
@@ -74,6 +74,7 @@ class ConnectorObjectDelegate extends AbstractICFBuilder<ConnectorObjectBuilder>
     }
 
     void attribute(@DelegatesTo(AttributeDelegate) Closure<?> attribute) {
+        attribute.resolveStrategy = Closure.DELEGATE_FIRST
         delegateToTag(AttributeDelegate, attribute)
     }
 

--- a/src/main/java/org/forgerock/openicf/misc/scriptedcommon/ScriptedConfiguration.java
+++ b/src/main/java/org/forgerock/openicf/misc/scriptedcommon/ScriptedConfiguration.java
@@ -2,7 +2,7 @@
  * DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013-2014 ForgeRock AS. All rights reserved.
- * Portions Copyright 2018-2022 Wren Security.
+ * Portions Copyright 2018-2025 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -737,7 +737,7 @@ public class ScriptedConfiguration extends AbstractConfiguration implements Stat
 
     private final ConcurrentMap<String, Log> loggerCache = new ConcurrentHashMap<String, Log>(11);
 
-    Object evaluate(String scriptName, Binding binding, Object delegate) throws Exception {
+    protected Object evaluate(String scriptName, Binding binding, Object delegate) throws Exception {
         try {
             Script scr = getGroovyScriptEngine().createScript(scriptName, binding);
             binding.setVariable(LOGGER, getLogger(scr.getClass()));

--- a/src/main/resources/META-INF/services/org.apache.groovy.transform.ASTTransformation
+++ b/src/main/resources/META-INF/services/org.apache.groovy.transform.ASTTransformation
@@ -2,4 +2,4 @@
 groovy.grape.GrabAnnotationTransformation
 
 #global transformation for AST Builder
-org.codehaus.groovy.ast.builder.AstBuilderTransformation
+org.apache.groovy.ast.builder.AstBuilderTransformation

--- a/src/test/resources/crest/SchemaSlurper.groovy
+++ b/src/test/resources/crest/SchemaSlurper.groovy
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyright 2022-2025 Wren Security.
  */
 
 import groovy.json.JsonOutput
@@ -140,7 +141,7 @@ class SchemaSlurper {
             [objectDefinition.nativeType,
              [resourceContainer: objectName,
               attributes       :
-                      objectDefinition.properties.collectEntries {String propertyName, Map propertyDefinition ->
+                      objectDefinition.get("properties").collectEntries {String propertyName, Map propertyDefinition ->
                           if (AttributeUtil.namesEqual(Uid.NAME, propertyDefinition.nativeName)) {
                               //Ignore it
                               return null


### PR DESCRIPTION
This PR introduces an upgrade to the latest Groovy release, version 5.0.2, with updated Maven coordinates. Additionally, the Maven Bundle Plugin now completely prepares OSGi metadata. The PR also upgrades some dependencies and Maven plugins.

**Breaking changes**

* Groovy Maven coordinates were changed from `org.codehaus.groovy` to `org.apache.groovy`.
* This PR changes `resolveStrategy` for the attribute _Closure_ ensuring that method calls are first resolved against the delegate (`AttributeDelegate`) before falling back to the owner. This is necessary to prevent usage of the `name` setter ([ConnectorObjectBuilder.java#L64](https://github.com/WrenSecurity/wrenicf-java-framework/blob/892bdaab250cdd1f4dca931efe4c919dd7c6db43/framework-core/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObjectBuilder.java#L64)) in the owner instance.