### PR TITLE
Use default Java version during Sonar analysis

### DIFF
--- a/.github/workflows/sonar-trigger.yml
+++ b/.github/workflows/sonar-trigger.yml
@@ -28,7 +28,6 @@ jobs:
     uses: WrenSecurity/.github/.github/workflows/sonar-maven.yml@main
     with:
       commit_sha: ${{ github.event.workflow_run.head_sha }}
-      java_version: 11
       project_key: 'WrenSecurity_wrenicf-groovy-connector'
       pull_request: ${{ needs.prepare.outputs.pull_request }}
     secrets:


### PR DESCRIPTION
This PR removes the `java_version` property, meaning the default value will be used. (https://github.com/WrenSecurity/.github/blob/main/.github/workflows/sonar-maven.yml#L13).