### PR TITLE
Add workflow condition to skip Sonar analysis in forked repositories

### DIFF
--- a/.github/workflows/sonar-trigger.yml
+++ b/.github/workflows/sonar-trigger.yml
@@ -16,14 +16,14 @@ permissions:
 
 jobs:
   prepare:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'WrenSecurity'
     uses: WrenSecurity/.github/.github/workflows/sonar-prepare.yml@main
     name: Prepare analysis context
     with:
       workflow_run: ${{ toJSON(github.event.workflow_run) }}
   trigger:
     needs: prepare
-    if: needs.prepare.outputs.sonar_allowed
+    if: needs.prepare.outputs.sonar_allowed == 'true'
     name: Trigger Sonar analysis
     uses: WrenSecurity/.github/.github/workflows/sonar-maven.yml@main
     with:


### PR DESCRIPTION
This PR adds a condition to the sonar-trigger.yml workflow to prevent Sonar analysis from running in forked repositories, where SONAR_TOKEN is not available and the workflow would always fail. The analysis now runs only for pull requests targeting the WrenSecurity repository (including from forks) and for direct pushes to the WrenSecurity repository.